### PR TITLE
Soft delete

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -176,6 +176,7 @@ function AppContent() {
   
   
   const [showSignOutConfirmModal, setShowSignOutConfirmModal] = useState(false);
+  const [configSessionToken, setConfigSessionToken] = useState(0);
 
   const executeSignOut = useCallback(async () => {
     // Clear dismissed modals state for new session
@@ -197,6 +198,10 @@ function AppContent() {
 
     await executeSignOut();
   }, [executeSignOut, gameState.matchState]);
+
+  const beginNewConfigurationSession = useCallback(() => {
+    setConfigSessionToken((prev) => prev + 1);
+  }, []);
 
   const handleConfirmSignOut = useCallback(async () => {
     setShowSignOutConfirmModal(false);
@@ -755,6 +760,8 @@ function AppContent() {
     gameState.resetScore();
     gameState.setOpponentTeam('');
     gameState.clearStoredState();
+
+    beginNewConfigurationSession();
   };
 
   const handleNewGameFromMenu = async () => {
@@ -936,6 +943,7 @@ function AppContent() {
             hasActiveConfiguration={gameState.hasActiveConfiguration}
             setHasActiveConfiguration={gameState.setHasActiveConfiguration}
             clearStoredState={gameState.clearStoredState}
+            configurationSessionId={configSessionToken}
           />
         );
       case VIEWS.PERIOD_SETUP:
@@ -1048,12 +1056,13 @@ function AppContent() {
             navigateToMatchReport={gameState.navigateToMatchReport}
             currentMatchId={gameState.currentMatchId}
             matchEvents={gameState.matchEvents || []}
-            goalScorers={gameState.goalScorers || {}}
-            authModal={authModal}
-            checkForActiveMatch={checkForActiveMatch}
-            selectedSquadIds={gameState.selectedSquadIds}
-          />
-        );
+          goalScorers={gameState.goalScorers || {}}
+          authModal={authModal}
+          checkForActiveMatch={checkForActiveMatch}
+          selectedSquadIds={gameState.selectedSquadIds}
+          onStartNewConfigurationSession={beginNewConfigurationSession}
+        />
+      );
       case VIEWS.MATCH_REPORT:
         return (
           <MatchReportScreen 

--- a/src/App.js
+++ b/src/App.js
@@ -395,6 +395,7 @@ function AppContent() {
         .from('match')
         .select('id, state')
         .eq('id', gameState.currentMatchId)
+        .is('deleted_at', null)
         .in('state', ['running', 'finished'])
         .single();
 
@@ -434,17 +435,22 @@ function AppContent() {
     }
   }, [gameState.currentMatchId]);
 
-  // Handle abandonment confirmation - delete match record and proceed
+  // Handle abandonment confirmation - mark match record as deleted and proceed
   const handleAbandonMatch = useCallback(async () => {
     try {
       if (gameState.currentMatchId) {
+        const nowIso = new Date().toISOString();
+
         const { error } = await supabase
           .from('match')
-          .delete()
-          .eq('id', gameState.currentMatchId);
+          .update({
+            deleted_at: nowIso
+          })
+          .eq('id', gameState.currentMatchId)
+          .is('deleted_at', null);
           
         if (error) {
-          console.error('Error deleting match record:', error);
+          console.error('Error marking match as deleted:', error);
           // Continue anyway - don't block user if deletion fails
         }
       }
@@ -518,17 +524,22 @@ function AppContent() {
     
   }, [gameState.currentMatchId, pendingNewGameCallback, showSuccessMessage]);
 
-  // Handle "Delete Match" option - delete database record and proceed
+  // Handle "Delete Match" option - mark database record as deleted and proceed
   const handleDeleteFinishedMatch = useCallback(async () => {
     try {
       if (gameState.currentMatchId) {
+        const nowIso = new Date().toISOString();
+
         const { error } = await supabase
           .from('match')
-          .delete()
-          .eq('id', gameState.currentMatchId);
+          .update({
+            deleted_at: nowIso
+          })
+          .eq('id', gameState.currentMatchId)
+          .is('deleted_at', null);
           
         if (error) {
-          console.error('Error deleting match record:', error);
+          console.error('Error marking match as deleted:', error);
           showSuccessMessage('Error deleting match. Please try again.');
         } else {
           showSuccessMessage('Match deleted successfully!');

--- a/src/components/setup/ConfigurationScreen.js
+++ b/src/components/setup/ConfigurationScreen.js
@@ -447,8 +447,6 @@ export function ConfigurationScreen({
         !newSignInProcessed &&
         clearStoredState) {
 
-      console.log('🔄 NEW_SIGN_IN detected with no active configuration - clearing previous user data');
-
       // Mark as processed to prevent infinite loops
       setNewSignInProcessed(true);
 

--- a/src/components/stats/StatsScreen.js
+++ b/src/components/stats/StatsScreen.js
@@ -38,7 +38,8 @@ export function StatsScreen({
   goalScorers,
   authModal,
   checkForActiveMatch,
-  selectedSquadIds = []
+  selectedSquadIds = [],
+  onStartNewConfigurationSession = () => {}
 }) {
   const [copySuccess, setCopySuccess] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
@@ -175,6 +176,7 @@ export function StatsScreen({
       setGameLog([]);
       resetScore(); // Clear score
       setOpponentTeam(''); // Clear opponent team name
+      onStartNewConfigurationSession();
       setView('config');
     });
   };

--- a/src/hooks/useMatchRecovery.js
+++ b/src/hooks/useMatchRecovery.js
@@ -126,7 +126,7 @@ export function useMatchRecovery({
         console.log('🗑️ Deleting abandoned recovered match:', recoveryMatch.id);
       }
 
-      // Delete match from database
+      // Soft delete match in database
       const deleteResult = await deleteAbandonedMatch(recoveryMatch.id);
       if (!deleteResult.success) {
         throw new Error(deleteResult.error);

--- a/src/services/__tests__/matchRecoveryService.test.js
+++ b/src/services/__tests__/matchRecoveryService.test.js
@@ -2,7 +2,6 @@ import {
   checkForRecoverableMatch,
   deleteAbandonedMatch,
   getRecoveryMatchData,
-  restoreSoftDeletedMatch,
   validateRecoveryData
 } from '../matchRecoveryService';
 import { supabase } from '../../lib/supabase';
@@ -10,8 +9,7 @@ import { supabase } from '../../lib/supabase';
 // Mock the supabase client
 jest.mock('../../lib/supabase', () => ({
   supabase: {
-    from: jest.fn(),
-    rpc: jest.fn()
+    from: jest.fn()
   }
 }));
 
@@ -255,65 +253,6 @@ describe('matchRecoveryService', () => {
         '❌ Exception while deleting abandoned match:',
         expect.any(Error)
       );
-    });
-  });
-
-  describe('restoreSoftDeletedMatch', () => {
-    it('requires matchId', async () => {
-      const result = await restoreSoftDeletedMatch();
-
-      expect(result).toEqual({
-        success: false,
-        error: 'Match ID is required'
-      });
-      expect(supabase.rpc).not.toHaveBeenCalled();
-    });
-
-    it('returns error when RPC fails', async () => {
-      supabase.rpc.mockResolvedValue({
-        data: null,
-        error: { message: 'permission denied' }
-      });
-
-      const result = await restoreSoftDeletedMatch('match-123');
-
-      expect(supabase.rpc).toHaveBeenCalledWith('restore_soft_deleted_match', {
-        p_match_id: 'match-123'
-      });
-      expect(result).toEqual({
-        success: false,
-        error: 'Database error: permission denied'
-      });
-    });
-
-    it('returns error when no match is restored', async () => {
-      supabase.rpc.mockResolvedValue({
-        data: null,
-        error: null
-      });
-
-      const result = await restoreSoftDeletedMatch('match-123');
-
-      expect(result).toEqual({
-        success: false,
-        error: 'Unable to restore match. It may not be soft deleted or accessible.'
-      });
-    });
-
-    it('returns restored match on success', async () => {
-      const restoredMatch = { id: 'match-123', deleted_at: null };
-
-      supabase.rpc.mockResolvedValue({
-        data: restoredMatch,
-        error: null
-      });
-
-      const result = await restoreSoftDeletedMatch('match-123');
-
-      expect(result).toEqual({
-        success: true,
-        match: restoredMatch
-      });
     });
   });
 

--- a/src/services/__tests__/matchRecoveryService.test.js
+++ b/src/services/__tests__/matchRecoveryService.test.js
@@ -24,9 +24,10 @@ const createSelectChain = ({ singleResult }) => {
 
 const createUpdateChain = response => {
   const isDeleted = jest.fn(() => Promise.resolve(response));
-  const eqId = jest.fn(() => ({ is: isDeleted }));
+  const eqState = jest.fn(() => ({ is: isDeleted }));
+  const eqId = jest.fn(() => ({ eq: eqState, is: isDeleted }));
   const update = jest.fn(() => ({ eq: eqId }));
-  return { update, eqId, isDeleted };
+  return { update, eqId, eqState, isDeleted };
 };
 
 // Mock the persistence manager
@@ -196,6 +197,7 @@ describe('matchRecoveryService', () => {
         deleted_at: expect.any(String)
       }));
       expect(chain.eqId).toHaveBeenCalledWith('id', 'match-123');
+      expect(chain.eqState).toHaveBeenCalledWith('state', 'finished');
       expect(chain.isDeleted).toHaveBeenCalledWith('deleted_at', null);
     });
 

--- a/src/services/__tests__/sessionDetectionService.test.js
+++ b/src/services/__tests__/sessionDetectionService.test.js
@@ -13,6 +13,8 @@ import {
   shouldShowRecoveryModal,
   resetSessionTracking,
   clearAllSessionData,
+  markPendingSignIn,
+  markSignOutGuard,
   DETECTION_TYPES
 } from '../sessionDetectionService';
 
@@ -27,12 +29,31 @@ const mockSessionStorage = {
   getItem: jest.fn((key) => mockSessionStorage.storage[key] || null),
   setItem: jest.fn((key, value) => { mockSessionStorage.storage[key] = value; }),
   removeItem: jest.fn((key) => { delete mockSessionStorage.storage[key]; }),
-  clear: jest.fn(() => { mockSessionStorage.storage = {}; })
+  clear: jest.fn(() => { mockSessionStorage.storage = {}; }),
+  key: jest.fn((index) => Object.keys(mockSessionStorage.storage)[index] || null)
 };
+
+Object.defineProperty(mockSessionStorage, 'length', {
+  get: () => Object.keys(mockSessionStorage.storage).length
+});
+
+const mockLocalStorage = {
+  storage: {},
+  getItem: jest.fn((key) => mockLocalStorage.storage[key] || null),
+  setItem: jest.fn((key, value) => { mockLocalStorage.storage[key] = value; }),
+  removeItem: jest.fn((key) => { delete mockLocalStorage.storage[key]; }),
+  clear: jest.fn(() => { mockLocalStorage.storage = {}; }),
+  key: jest.fn((index) => Object.keys(mockLocalStorage.storage)[index] || null)
+};
+
+Object.defineProperty(mockLocalStorage, 'length', {
+  get: () => Object.keys(mockLocalStorage.storage).length
+});
 
 // Setup global mocks
 global.performance = mockPerformance;
 global.sessionStorage = mockSessionStorage;
+global.localStorage = mockLocalStorage;
 
 // Mock console.log for debug testing
 const originalConsoleLog = console.log;
@@ -43,7 +64,10 @@ describe('sessionDetectionService', () => {
     // Clear all mocks and storage
     jest.clearAllMocks();
     mockSessionStorage.storage = {};
-    
+    mockSessionStorage.key.mockClear();
+    mockLocalStorage.storage = {};
+    mockLocalStorage.key.mockClear();
+
     // Reset performance mock
     mockPerformance.navigation = { type: 0 };
     mockPerformance.getEntriesByType.mockReturnValue([]);
@@ -77,6 +101,44 @@ describe('sessionDetectionService', () => {
       expect([DETECTION_TYPES.NEW_SIGN_IN, DETECTION_TYPES.PAGE_REFRESH]).toContain(result.type);
       expect(typeof result.confidence).toBe('number');
       expect(typeof result.timestamp).toBe('number');
+    });
+
+    it('should treat fresh loads without a Supabase session as PAGE_REFRESH', () => {
+      const result = detectSessionType();
+
+      expect(result.type).toBe(DETECTION_TYPES.PAGE_REFRESH);
+      expect(result.signals.session.hasSupabaseSession).toBe(false);
+    });
+
+    it('should detect NEW_SIGN_IN when pending sign-in flag is set', () => {
+      markPendingSignIn();
+
+      const result = detectSessionType();
+
+      expect(result.type).toBe(DETECTION_TYPES.NEW_SIGN_IN);
+      expect(result.signals.session.hasSupabaseSession).toBe(false);
+    });
+
+    it('should suppress NEW_SIGN_IN immediately after a recent sign-out', () => {
+      markSignOutGuard();
+
+      const result = detectSessionType();
+
+      expect(result.type).toBe(DETECTION_TYPES.PAGE_REFRESH);
+      expect(result.signals.session.hasSupabaseSession).toBe(false);
+    });
+
+    it('should detect NEW_SIGN_IN once guard is consumed and auth token becomes available', () => {
+      markSignOutGuard();
+      const guardedResult = detectSessionType();
+      expect(guardedResult.type).toBe(DETECTION_TYPES.PAGE_REFRESH);
+
+      resetSessionTracking();
+      mockSessionStorage.storage['sb-test-auth-token'] = 'token-value';
+
+      const signInResult = detectSessionType();
+      expect(signInResult.type).toBe(DETECTION_TYPES.NEW_SIGN_IN);
+      expect(signInResult.signals.session.hasSupabaseSession).toBe(true);
     });
 
     it('should include navigation and session signals', () => {
@@ -402,6 +464,25 @@ describe('sessionDetectionService', () => {
         expect(result.type).toBeDefined();
         expect(typeof result.confidence).toBe('number');
       });
+    });
+
+    it('should not flag established sessions as NEW_SIGN_IN during in-app actions', () => {
+      // Simulate authenticated session with Supabase token present
+      mockSessionStorage.storage['sb-test-auth-token'] = 'token-value';
+
+      const initialDetection = detectSessionType();
+      expect(initialDetection.type).toBe(DETECTION_TYPES.NEW_SIGN_IN);
+
+      // Remove cache so follow-up detection performs full evaluation
+      delete mockSessionStorage.storage['sport-wizard-detection-cache'];
+
+      const now = Date.now().toString();
+      mockSessionStorage.storage['sport-wizard-last-activity'] = now;
+      mockSessionStorage.storage['sport-wizard-auth-timestamp'] = now;
+      mockSessionStorage.storage['sport-wizard-page-load-count'] = '5';
+
+      const followUpDetection = detectSessionType();
+      expect(followUpDetection.type).toBe(DETECTION_TYPES.PAGE_REFRESH);
     });
   });
 });

--- a/src/services/matchCleanupService.js
+++ b/src/services/matchCleanupService.js
@@ -28,47 +28,83 @@ export async function cleanupAbandonedMatches() {
     };
 
     // Clean up running matches older than 5 hours using started_at to avoid deleting newly resumed games
-    const { data: deletedRunning, error: runningError } = await supabase
+    const { data: runningCandidates, error: runningFetchError } = await supabase
       .from('match')
-      .update(softDeletePayload)
+      .select('id')
       .eq('state', 'running')
       .is('deleted_at', null)
       .not('started_at', 'is', null)
-      .lt('started_at', runningCutoff.toISOString())
-      .select('id');
+      .lt('started_at', runningCutoff.toISOString());
 
-    if (runningError) {
-      console.error('❌ Failed to cleanup running matches:', runningError);
+    if (runningFetchError) {
+      console.error('❌ Failed to fetch running matches for cleanup:', runningFetchError);
       return {
         success: false,
         cleanedRunning: 0,
         cleanedFinished: 0,
-        error: `Failed to cleanup running matches: ${runningError.message}`
+        error: `Failed to fetch running matches: ${runningFetchError.message}`
       };
+    }
+
+    const runningIds = runningCandidates?.map(match => match.id) || [];
+
+    if (runningIds.length > 0) {
+      const { error: runningUpdateError } = await supabase
+        .from('match')
+        .update(softDeletePayload, { returning: 'minimal' })
+        .in('id', runningIds);
+
+      if (runningUpdateError) {
+        console.error('❌ Failed to cleanup running matches:', runningUpdateError);
+        return {
+          success: false,
+          cleanedRunning: 0,
+          cleanedFinished: 0,
+          error: `Failed to cleanup running matches: ${runningUpdateError.message}`
+        };
+      }
     }
 
     // Clean up finished matches older than 14 days
-    const { data: deletedFinished, error: finishedError } = await supabase
+    const { data: finishedCandidates, error: finishedFetchError } = await supabase
       .from('match')
-      .update(softDeletePayload)
+      .select('id')
       .eq('state', 'finished')
       .is('deleted_at', null)
       .not('finished_at', 'is', null)
-      .lt('finished_at', finishedCutoff.toISOString())
-      .select('id');
+      .lt('finished_at', finishedCutoff.toISOString());
 
-    if (finishedError) {
-      console.error('❌ Failed to cleanup finished matches:', finishedError);
+    if (finishedFetchError) {
+      console.error('❌ Failed to fetch finished matches for cleanup:', finishedFetchError);
       return {
         success: false,
-        cleanedRunning: deletedRunning?.length || 0,
+        cleanedRunning: runningIds.length,
         cleanedFinished: 0,
-        error: `Failed to cleanup finished matches: ${finishedError.message}`
+        error: `Failed to fetch finished matches: ${finishedFetchError.message}`
       };
     }
 
-    const cleanedRunning = deletedRunning?.length || 0;
-    const cleanedFinished = deletedFinished?.length || 0;
+    const finishedIds = finishedCandidates?.map(match => match.id) || [];
+
+    if (finishedIds.length > 0) {
+      const { error: finishedUpdateError } = await supabase
+        .from('match')
+        .update(softDeletePayload, { returning: 'minimal' })
+        .in('id', finishedIds);
+
+      if (finishedUpdateError) {
+        console.error('❌ Failed to cleanup finished matches:', finishedUpdateError);
+        return {
+          success: false,
+          cleanedRunning: runningIds.length,
+          cleanedFinished: 0,
+          error: `Failed to cleanup finished matches: ${finishedUpdateError.message}`
+        };
+      }
+    }
+
+    const cleanedRunning = runningIds.length;
+    const cleanedFinished = finishedIds.length;
     const totalCleaned = cleanedRunning + cleanedFinished;
 
     if (totalCleaned > 0) {

--- a/src/services/matchRecoveryService.js
+++ b/src/services/matchRecoveryService.js
@@ -116,6 +116,54 @@ export async function deleteAbandonedMatch(matchId) {
 }
 
 /**
+ * Restore a soft-deleted match via controlled RPC
+ *
+ * @param {string} matchId - Match identifier to restore
+ * @returns {Promise<{success: boolean, match?: Object, error?: string}>}
+ */
+export async function restoreSoftDeletedMatch(matchId) {
+  try {
+    if (!matchId) {
+      return {
+        success: false,
+        error: 'Match ID is required'
+      };
+    }
+
+    const { data: restoredMatch, error } = await supabase.rpc('restore_soft_deleted_match', {
+      p_match_id: matchId
+    });
+
+    if (error) {
+      console.error('❌ Failed to restore soft-deleted match:', error);
+      return {
+        success: false,
+        error: `Database error: ${error.message}`
+      };
+    }
+
+    if (!restoredMatch) {
+      return {
+        success: false,
+        error: 'Unable to restore match. It may not be soft deleted or accessible.'
+      };
+    }
+
+    return {
+      success: true,
+      match: restoredMatch
+    };
+
+  } catch (error) {
+    console.error('❌ Exception while restoring soft-deleted match:', error);
+    return {
+      success: false,
+      error: `Unexpected error: ${error.message}`
+    };
+  }
+}
+
+/**
  * Get match statistics from localStorage for recovery
  * 
  * @deprecated This function is no longer needed as player_match_stats are stored in database when match is created

--- a/src/services/matchRecoveryService.js
+++ b/src/services/matchRecoveryService.js
@@ -37,6 +37,7 @@ export async function checkForRecoverableMatch() {
       .from('match')
       .select('*')
       .eq('id', currentMatchId)
+      .is('deleted_at', null)
       .eq('state', 'finished') // Only finished matches can be recovered
       .single();
 
@@ -84,10 +85,15 @@ export async function deleteAbandonedMatch(matchId) {
     }
 
 
+    const nowIso = new Date().toISOString();
+
     const { error } = await supabase
       .from('match')
-      .delete()
-      .eq('id', matchId);
+      .update({
+        deleted_at: nowIso
+      })
+      .eq('id', matchId)
+      .is('deleted_at', null);
 
     if (error) {
       console.error('❌ Failed to delete abandoned match:', error);

--- a/src/services/matchRecoveryService.js
+++ b/src/services/matchRecoveryService.js
@@ -93,6 +93,7 @@ export async function deleteAbandonedMatch(matchId) {
         deleted_at: nowIso
       })
       .eq('id', matchId)
+      .eq('state', 'finished')
       .is('deleted_at', null);
 
     if (error) {

--- a/src/services/matchRecoveryService.js
+++ b/src/services/matchRecoveryService.js
@@ -116,54 +116,6 @@ export async function deleteAbandonedMatch(matchId) {
 }
 
 /**
- * Restore a soft-deleted match via controlled RPC
- *
- * @param {string} matchId - Match identifier to restore
- * @returns {Promise<{success: boolean, match?: Object, error?: string}>}
- */
-export async function restoreSoftDeletedMatch(matchId) {
-  try {
-    if (!matchId) {
-      return {
-        success: false,
-        error: 'Match ID is required'
-      };
-    }
-
-    const { data: restoredMatch, error } = await supabase.rpc('restore_soft_deleted_match', {
-      p_match_id: matchId
-    });
-
-    if (error) {
-      console.error('❌ Failed to restore soft-deleted match:', error);
-      return {
-        success: false,
-        error: `Database error: ${error.message}`
-      };
-    }
-
-    if (!restoredMatch) {
-      return {
-        success: false,
-        error: 'Unable to restore match. It may not be soft deleted or accessible.'
-      };
-    }
-
-    return {
-      success: true,
-      match: restoredMatch
-    };
-
-  } catch (error) {
-    console.error('❌ Exception while restoring soft-deleted match:', error);
-    return {
-      success: false,
-      error: `Unexpected error: ${error.message}`
-    };
-  }
-}
-
-/**
  * Get match statistics from localStorage for recovery
  * 
  * @deprecated This function is no longer needed as player_match_stats are stored in database when match is created

--- a/src/services/matchStateManager.js
+++ b/src/services/matchStateManager.js
@@ -1102,9 +1102,12 @@ export async function discardPendingMatch(matchId) {
 
     const { error } = await supabase
       .from('match')
-      .update({
-        deleted_at: nowIso
-      })
+      .update(
+        {
+          deleted_at: nowIso
+        },
+        { returning: 'minimal' }
+      )
       .eq('id', matchId)
       .is('deleted_at', null)
       .eq('state', 'pending'); // Only update pending matches

--- a/src/services/matchStateManager.js
+++ b/src/services/matchStateManager.js
@@ -123,14 +123,17 @@ export async function updateMatchToRunning(matchId) {
     }
 
 
+    const nowIso = new Date().toISOString();
+
     const { error } = await supabase
       .from('match')
-      .update({ 
+      .update({
         state: 'running',
-        started_at: new Date().toISOString(),
-        updated_at: new Date().toISOString()
+        started_at: nowIso,
+        updated_at: nowIso
       })
       .eq('id', matchId)
+      .is('deleted_at', null)
       .eq('state', 'pending'); // Only update if currently pending
 
     if (error) {
@@ -194,6 +197,7 @@ export async function updateMatchToFinished(matchId, finalStats, allPlayers = []
       .from('match')
       .update(updateData)
       .eq('id', matchId)
+      .is('deleted_at', null)
       .eq('state', 'running'); // Only update if currently running
 
     if (error) {
@@ -251,6 +255,7 @@ export async function updateMatchToConfirmed(matchId, fairPlayAwardId = null) {
       .from('match')
       .update(updateData)
       .eq('id', matchId)
+      .is('deleted_at', null)
       .eq('state', 'finished')
       .select('id'); // Ensure at least one row was updated
 
@@ -366,6 +371,7 @@ export async function getMatch(matchId) {
       .from('match')
       .select('*')
       .eq('id', matchId)
+      .is('deleted_at', null)
       .single();
 
     if (error) {
@@ -407,6 +413,7 @@ export async function checkForRunningMatch(teamId) {
       .select('id')
       .eq('team_id', teamId)
       .eq('state', 'running')
+      .is('deleted_at', null)
       .limit(1);
 
     if (error) {
@@ -818,6 +825,7 @@ export async function updateExistingMatch(matchId, matchData) {
       .from('match')
       .update(updateData)
       .eq('id', matchId)
+      .is('deleted_at', null)
       .eq('state', 'pending'); // Only update pending matches
 
     if (error) {
@@ -1000,6 +1008,7 @@ export async function saveInitialMatchConfig(matchId, initialConfig) {
         updated_at: new Date().toISOString()
       })
       .eq('id', matchId)
+      .is('deleted_at', null)
       .eq('state', 'pending'); // Only update pending matches
 
     if (error) {
@@ -1039,6 +1048,7 @@ export async function getPendingMatchForTeam(teamId) {
       .from('match')
       .select('*')
       .eq('team_id', teamId)
+      .is('deleted_at', null)
       .eq('state', 'pending')
       .order('created_at', { ascending: false })
       .limit(1)
@@ -1087,12 +1097,17 @@ export async function discardPendingMatch(matchId) {
       .delete()
       .eq('match_id', matchId);
 
-    // Then delete the match itself
+    // Then soft delete the match record
+    const nowIso = new Date().toISOString();
+
     const { error } = await supabase
       .from('match')
-      .delete()
+      .update({
+        deleted_at: nowIso
+      })
       .eq('id', matchId)
-      .eq('state', 'pending'); // Only delete pending matches
+      .is('deleted_at', null)
+      .eq('state', 'pending'); // Only update pending matches
 
     if (error) {
       console.error('❌ Failed to discard pending match:', error);

--- a/src/services/pendingMatchService.js
+++ b/src/services/pendingMatchService.js
@@ -25,6 +25,7 @@ export async function checkForPendingMatches(teamId) {
       .from('match')
       .select('*')
       .eq('team_id', teamId)
+      .is('deleted_at', null)
       .eq('state', 'pending')
       .order('created_at', { ascending: false });
 

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -65,6 +65,7 @@ export type Database = {
         Row: {
           captain: string | null
           created_at: string
+          deleted_at: string | null
           fair_play_award: string | null
           finished_at: string | null
           format: Database["public"]["Enums"]["match_format"]
@@ -87,6 +88,7 @@ export type Database = {
         Insert: {
           captain?: string | null
           created_at?: string
+          deleted_at?: string | null
           fair_play_award?: string | null
           finished_at?: string | null
           format?: Database["public"]["Enums"]["match_format"]
@@ -109,6 +111,7 @@ export type Database = {
         Update: {
           captain?: string | null
           created_at?: string
+          deleted_at?: string | null
           fair_play_award?: string | null
           finished_at?: string | null
           format?: Database["public"]["Enums"]["match_format"]

--- a/src/utils/DataSyncManager.js
+++ b/src/utils/DataSyncManager.js
@@ -265,6 +265,7 @@ export class DataSyncManager {
           player_match_stats (*)
         `)
         .eq('team.team_user.user_id', this.userId)
+        .is('deleted_at', null)
         .order('finished_at', { ascending: false })
         .limit(limit);
 

--- a/supabase/migrations/20250920000000_add_match_deleted_at.sql
+++ b/supabase/migrations/20250920000000_add_match_deleted_at.sql
@@ -1,0 +1,12 @@
+-- Add soft delete support for match records
+
+ALTER TABLE public.match
+  ADD COLUMN IF NOT EXISTS deleted_at timestamptz;
+
+COMMENT ON COLUMN public.match.deleted_at IS 'Timestamp when the match was soft deleted.';
+
+-- Index deleted_at to speed up filters that exclude soft-deleted rows
+CREATE INDEX IF NOT EXISTS idx_match_deleted_at ON public.match(deleted_at);
+
+-- Keep common state lookups fast for non-deleted records
+CREATE INDEX IF NOT EXISTS idx_match_state_not_deleted ON public.match(state) WHERE deleted_at IS NULL;

--- a/supabase/migrations/20250924100000_harden_match_soft_delete.sql
+++ b/supabase/migrations/20250924100000_harden_match_soft_delete.sql
@@ -1,0 +1,85 @@
+-- Harden match soft delete policies and add controlled restore RPC
+
+-- Drop legacy match policies that did not account for deleted_at
+DROP POLICY IF EXISTS "Team members can view matches" ON public.match;
+DROP POLICY IF EXISTS "Team coaches can manage matches" ON public.match;
+
+-- Ensure only active matches are visible to team members
+CREATE POLICY "Team members can view active matches" ON public.match
+  FOR SELECT TO authenticated
+  USING (
+    public.is_team_member(team_id, auth.uid())
+    AND deleted_at IS NULL
+  );
+
+-- Allow team managers to insert new matches in active state
+CREATE POLICY "Team coaches can create matches" ON public.match
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    public.is_team_manager(team_id, auth.uid())
+    AND deleted_at IS NULL
+  );
+
+-- Allow team managers to update active matches (including soft deletion)
+CREATE POLICY "Team coaches can update active matches" ON public.match
+  FOR UPDATE TO authenticated
+  USING (
+    public.is_team_manager(team_id, auth.uid())
+    AND deleted_at IS NULL
+  )
+  WITH CHECK (
+    public.is_team_manager(team_id, auth.uid())
+  );
+
+-- Controlled restore function for soft-deleted matches
+CREATE OR REPLACE FUNCTION public.restore_soft_deleted_match(p_match_id uuid)
+RETURNS public.match
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_match public.match;
+  v_user uuid;
+BEGIN
+  v_user := auth.uid();
+
+  IF v_user IS NULL THEN
+    RAISE EXCEPTION 'Restore requires authentication' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT * INTO v_match
+  FROM public.match
+  WHERE id = p_match_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Match % not found', p_match_id USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_match.deleted_at IS NULL THEN
+    RAISE EXCEPTION 'Match % is not soft deleted', p_match_id USING ERRCODE = '20000';
+  END IF;
+
+  IF NOT public.is_team_manager(v_match.team_id, v_user) THEN
+    RAISE EXCEPTION 'Only team managers can restore matches' USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE public.match
+    SET deleted_at = NULL,
+        updated_at = now()
+  WHERE id = p_match_id;
+
+  RETURN (
+    SELECT m
+    FROM public.match AS m
+    WHERE m.id = p_match_id
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.restore_soft_deleted_match(uuid)
+  IS 'Restores a soft-deleted match when invoked by a team manager';
+
+REVOKE ALL ON FUNCTION public.restore_soft_deleted_match(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.restore_soft_deleted_match(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.restore_soft_deleted_match(uuid) TO service_role;


### PR DESCRIPTION
 - Add deleted_at soft-delete support for matches, update Supabase types, and adjust cleanup/recovery to rely on started_at/finished_at without touching updated_at.
  - Guard every match read/write (app flows, pending/recovery services, DataSync) against soft-deleted rows and convert destructive deletes to soft deletes.
  - Refresh match-related unit tests with proper Supabase chain mocks and re-run full test suite.

