### PR TITLE
Align configuration gating with format-specific squad minimums

### DIFF
--- a/src/constants/teamConfiguration.js
+++ b/src/constants/teamConfiguration.js
@@ -152,6 +152,23 @@ export const FORMAT_CONFIGS = {
   }
 };
 
+/**
+ * Determine minimum players required for a given format (goalie + field players)
+ * Falls back to global minimum squad size if format metadata is unavailable
+ * @param {string} format - Team format identifier (e.g., 5v5, 7v7)
+ * @returns {number} Minimum players required to satisfy the format
+ */
+export function getMinimumPlayersForFormat(format) {
+  const formatConfig = FORMAT_CONFIGS[format];
+  const goalieCount = GAME_CONSTANTS.GOALIE_COUNT ?? 1;
+  if (!formatConfig || typeof formatConfig.fieldPlayers !== 'number') {
+    return GAME_CONSTANTS.MIN_SQUAD_SIZE;
+  }
+
+  const minimumPlayers = formatConfig.fieldPlayers + goalieCount;
+  return Math.max(GAME_CONSTANTS.MIN_SQUAD_SIZE, minimumPlayers);
+}
+
 // Pair role rotation styles (for pairs substitution mode)
 export const PAIR_ROLE_ROTATION_TYPES = {
   KEEP_THROUGHOUT_PERIOD: 'keep_throughout_period',


### PR DESCRIPTION
  - Added getMinimumPlayersForFormat helper in src/constants/teamConfiguration.js so formats expose their required squad size.
  - Updated ConfigurationScreen to gate formation controls, goalie/captain panels, and save/proceed buttons using the format-aware minimum and shared max limit.
  - Synced useGameState alerts/validation with the new dynamic minimum to keep runtime checks consistent.